### PR TITLE
Added CSV Emitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +143,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +189,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "clap",
+ "csv",
  "futures",
  "reqwest",
  "serde",
@@ -330,7 +365,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -371,7 +406,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -427,6 +462,12 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -682,6 +723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,7 +845,7 @@ version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
- "itoa",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -810,7 +857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/hgrsd/findcar"
 async-recursion = "1"
 async-trait = "0.1.58"
 clap = { version = "4.0.18", features = ["derive"] }
+csv = "1.1.6"
 futures = "0.3.25"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Options:
       --limit <LIMIT>
           Optional, maximum number of results to return
       --emitter <EMITTER>
-          Optional, emitter for the results. Options are: json, text. Default is text
+          Optional, emitter for the results. Options are: csv, json, text. Default is text
       --search-engine <SEARCH_ENGINE>
           Optional, search engine to use. Options are donedeal_ie, carzone_ie. 
           Default is to use all available engines. 

--- a/src/args.rs
+++ b/src/args.rs
@@ -48,7 +48,7 @@ pub struct Args {
     #[arg(long)]
     pub limit: Option<usize>,
 
-    /// Optional, emitter for the results. Options are: json, text. Default is text.
+    /// Optional, emitter for the results. Options are: csv, json, text. Default is text.
     #[arg(long)]
     pub emitter: Option<String>,
 

--- a/src/emit/csv.rs
+++ b/src/emit/csv.rs
@@ -1,0 +1,22 @@
+use crate::hit::Hit;
+
+use super::Emit;
+
+pub struct CsvEmitter {}
+
+impl CsvEmitter {
+    pub fn new() -> Self {
+        CsvEmitter {}
+    }
+}
+
+impl Emit for CsvEmitter {
+    fn emit(&self, hits: Vec<Hit>) {
+        let mut wtr = csv::Writer::from_writer(vec![]);
+
+        for hit in hits {
+            wtr.serialize(hit).unwrap();
+        }
+        println!("{}", String::from_utf8(wtr.into_inner().unwrap()).unwrap());
+    }
+}

--- a/src/emit/csv.rs
+++ b/src/emit/csv.rs
@@ -12,11 +12,11 @@ impl CsvEmitter {
 
 impl Emit for CsvEmitter {
     fn emit(&self, hits: Vec<Hit>) {
-        let mut wtr = csv::Writer::from_writer(vec![]);
+        let mut wtr = csv::Writer::from_writer(std::io::stdout());
 
         for hit in hits {
             wtr.serialize(hit).unwrap();
         }
-        println!("{}", String::from_utf8(wtr.into_inner().unwrap()).unwrap());
+        wtr.flush().expect("Error flushing CSV to stdout");
     }
 }

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -1,7 +1,9 @@
 use crate::hit::Hit;
 
+mod csv;
 mod json;
 mod text;
+pub use self::csv::CsvEmitter;
 pub use json::JsonEmitter;
 pub use text::TextEmitter;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod post_processing;
 mod query;
 mod search;
 
-use emit::{Emit, JsonEmitter, TextEmitter};
+use emit::{CsvEmitter, Emit, JsonEmitter, TextEmitter};
 use post_processing::{Action, Pipeline};
 
 #[tokio::main]
@@ -47,6 +47,8 @@ async fn main() {
         Some(val) => {
             if val.to_uppercase() == "JSON" {
                 Box::new(JsonEmitter::new())
+            } else if val.to_uppercase() == "CSV" {
+                Box::new(CsvEmitter::new())
             } else {
                 Box::new(TextEmitter::new())
             }


### PR DESCRIPTION
Resolves #1 

Added csv crate that can use serde serialiser to emit the data in a csv format.

I was unable to run the code locally but setup some mock data to test the output:
```
search_engine,make,model,mileage,year,price,url
dodgy_dealer.ie,Lada,Wheel Barrow,5,1980,10,www.lada.com
dodgy_dealer.ie,Lada,Mirage,10,1981,15,www.lada.com
```

The code in this repo is quite clean & notice you may or may not be Irish also, so happy to collab on any future changes if you want.